### PR TITLE
remove query builder

### DIFF
--- a/src/BaseSampler.php
+++ b/src/BaseSampler.php
@@ -2,15 +2,15 @@
 
 namespace PHParrot\Parrot;
 
-use Doctrine\DBAL\Connection;
 use PHParrot\Parrot\Database\SourceDatabase;
+use PHParrot\Parrot\Sampler\Sampler;
 
 /**
  * Abstract BaseSampler class with some common functionality.
  *
  * Not for use as a type hint, use Sampler for that
  */
-abstract class BaseSampler
+abstract class BaseSampler implements Sampler
 {
     /**
      * Table on which the sampler is operating
@@ -48,6 +48,7 @@ abstract class BaseSampler
      */
     protected $config;
 
+    abstract protected function fetchData(): array;
 
     public function __construct(
         \stdClass $config,
@@ -64,13 +65,9 @@ abstract class BaseSampler
         $this->tableName = $tableName;
     }
 
-    /**
-     * Naïve implementation - grab all rows and insert
-     *
-     */
-    public function execute(): array
+    public function getRows(): array
     {
-        $rows = $this->getRows();
+        $rows = $this->fetchData();
         $references = [];
 
         foreach ($this->referenceFields as $key => $variable) {
@@ -91,23 +88,5 @@ abstract class BaseSampler
         }
 
         return $rows;
-    }
-
-    /**
-     * Convenience method to assert presence of a config key while fetching
-     *
-     * @param \stdClass $config Config block
-     * @param string $key Key to be found in block
-     *
-     * @return mixed
-     * @throws \RuntimeException If required key missing
-     */
-    protected function demandParameterValue($config, $key)
-    {
-        if (!isset($config->$key)) {
-            throw new \RuntimeException("'$key' missing from config required by " . get_called_class());
-        }
-
-        return $config->$key;
     }
 }

--- a/src/Migrator/Migrator.php
+++ b/src/Migrator/Migrator.php
@@ -2,7 +2,6 @@
 
 namespace PHParrot\Parrot\Migrator;
 
-use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use PHParrot\Parrot\Cleaner\FieldCleaner;
 use PHParrot\Parrot\Cleaner\RowCleaner;
@@ -45,7 +44,6 @@ class Migrator
         DestinationDatabase $destination,
         LoggerInterface $logger
     ) {
-    
         $this->source = $source;
         $this->destination = $destination;
         $this->logger = $logger;
@@ -78,7 +76,7 @@ class Migrator
 
             try {
                 $this->ensureEmptyTargetTable($table);
-                $rows = $sampler->execute();
+                $rows = $sampler->getRows();
 
                 foreach ($rows as $row) {
                     $writer->write($table, $cleaner->cleanRow($row));
@@ -128,7 +126,6 @@ class Migrator
         string $setName,
         TableCollection $tableCollection
     ): void {
-    
         try {
             foreach ($tableCollection->getTables() as $table => $sampler) {
                 $this->destination->migrateTableTriggers($this->source->getTriggersDefinition($table));
@@ -150,7 +147,6 @@ class Migrator
         string $view,
         string $setName
     ): void {
-    
         $this->destination->dropView($view);
         $this->destination->createView($this->source->getViewDefinition($view));
 

--- a/src/ReferenceStore.php
+++ b/src/ReferenceStore.php
@@ -1,34 +1,18 @@
 <?php
 
-
 namespace PHParrot\Parrot;
 
 class ReferenceStore
 {
     protected $references = [];
 
-    /**
-     * Store an array of references by name for later use
-     *
-     * @param string $name       Variable name to store against
-     * @param array  $references Array of references to store
-     *
-     * @return void
-     */
-    public function setReferencesByName($name, $references)
+    public function setReferencesByName(string $name, array $references): void
     {
         $this->references[$name] = $references;
     }
 
-    /**
-     * Return array of references by name
-     *
-     * @param string $name Variable name to look up
-     *
-     * @return array
-     */
-    public function getReferencesByName($name, $default = [])
+    public function getReferencesByName(string $name): array
     {
-        return array_key_exists($name, $this->references) ? $this->references[$name] : $default;
+        return isset($this->references[$name]) ? $this->references[$name] : [];
     }
 }

--- a/src/Sampler/AllRows.php
+++ b/src/Sampler/AllRows.php
@@ -2,23 +2,38 @@
 
 namespace PHParrot\Parrot\Sampler;
 
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHParrot\Parrot\BaseSampler;
+use PHParrot\Parrot\Sampler\Exception\TableNotFound;
 
-class AllRows extends BaseSampler implements Sampler
+class AllRows extends BaseSampler
 {
     public function getName(): string
     {
         return 'All';
     }
 
-    public function getRows(): array
+    public function fetchData(): array
     {
-        $query = $this->source->getConnection()->createQueryBuilder()->select('*')->from($this->tableName);
+        $query = "SELECT * FROM " . $this->source->getConnection()->quote($this->tableName);
 
         if ($this->limit) {
-            $query->setMaxResults($this->limit);
+            $query .= " LIMIT " . $this->limit;
         }
 
-        return $query->execute()->fetchAll();
+        try {
+            $statement = $this->source->getConnection()->executeQuery($query);
+        } catch (TableNotFoundException $exception) {
+            throw new TableNotFound(
+                sprintf(
+                    "Table %s does not exist",
+                    $this->tableName
+                ),
+                0,
+                $exception
+            );
+        }
+
+        return $statement->fetchAllAssociative();
     }
 }

--- a/src/Sampler/Exception/RequiredConfigurationValueNotProvided.php
+++ b/src/Sampler/Exception/RequiredConfigurationValueNotProvided.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PHParrot\Parrot\Sampler\Exception;
+
+class RequiredConfigurationValueNotProvided extends \RuntimeException
+{
+}

--- a/src/Sampler/Exception/TableNotFound.php
+++ b/src/Sampler/Exception/TableNotFound.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PHParrot\Parrot\Sampler\Exception;
+
+class TableNotFound extends \RuntimeException
+{
+}

--- a/src/Sampler/None.php
+++ b/src/Sampler/None.php
@@ -7,14 +7,14 @@ use PHParrot\Parrot\BaseSampler;
 /**
  * Essentially a 'no-op' table sampler - allows tables to be specified as required without copying any data
  */
-class None extends BaseSampler implements Sampler
+class None extends BaseSampler
 {
     public function getName(): string
     {
         return 'None';
     }
 
-    public function getRows(): array
+    public function fetchData(): array
     {
         return [];
     }

--- a/src/Sampler/Sampler.php
+++ b/src/Sampler/Sampler.php
@@ -1,11 +1,12 @@
 <?php
 
-
 namespace PHParrot\Parrot\Sampler;
 
 interface Sampler
 {
     public function getName(): string;
 
+    // make this protected, and probably move everything onto BaseSampler
+    // make BaseSampler implement this interface instead
     public function getRows(): array;
 }

--- a/tests/Sampler/AllRowsTest.php
+++ b/tests/Sampler/AllRowsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PHParrot\Parrot\Tests\Sampler;
+
+use PHParrot\Parrot\ReferenceStore;
+use PHParrot\Parrot\Sampler\AllRows;
+use PHParrot\Parrot\Sampler\Exception\TableNotFound;
+
+class AllRowsTest extends SamplerTest
+{
+    public function testAllRowsAreReturned(): void
+    {
+        $sampler = new AllRows(
+            new \stdClass,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->assertSame(4, count($sampler->getRows()));
+    }
+
+    public function testRowsAreFiltered(): void
+    {
+        $config = new \stdClass();
+
+        $config->limit = 2;
+
+        $sampler = new AllRows(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->assertSame(2, count($sampler->getRows()));
+    }
+
+    public function testAnExceptionIsThrownIfTableDoesNotExist(): void
+    {
+        $sampler = new AllRows(
+            new \stdClass(),
+            new ReferenceStore(),
+            $this->source,
+            'TABLE_THAT_DOES_NOT_EXIST'
+        );
+
+        $this->expectException(TableNotFound::class);
+        $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
+        $sampler->getRows();
+    }
+}

--- a/tests/Sampler/MatchedRowsTest.php
+++ b/tests/Sampler/MatchedRowsTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace PHParrot\Parrot\Tests\Sampler;
+
+use PHParrot\Parrot\ReferenceStore;
+use PHParrot\Parrot\Sampler\Exception\TableNotFound;
+use PHParrot\Parrot\Sampler\MatchedRows;
+
+class MatchedRowsTest extends SamplerTest
+{
+    public function testMatchedRowsAreReturned(): void
+    {
+        $config = new \stdClass();
+        $config->constraints = new \stdClass();
+
+        $config->constraints->name = [
+            'apple',
+            'pear'
+        ];
+
+        $sampler = new MatchedRows(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    'id' => 2,
+                    'name' => 'pear'
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'apple'
+                ]
+            ],
+            $sampler->getRows()
+        );
+    }
+
+    public function testRowsAreMatchedByReferenceConstraint(): void
+    {
+        $config = new \stdClass();
+        $config->constraints = new \stdClass();
+
+        $config->constraints->id = '$fruit_ids';
+
+        $referenceStore = new ReferenceStore();
+        $referenceStore->setReferencesByName('fruit_ids', [1, 4]);
+
+        $sampler = new MatchedRows(
+            $config,
+            $referenceStore,
+            $this->source,
+            'fruits'
+        );
+
+        $this->assertEquals(
+            [
+                [
+                    'id' => 1,
+                    'name' => 'banana'
+                ],
+                [
+                    'id' => 4,
+                    'name' => 'cherry'
+                ]
+            ],
+            $sampler->getRows()
+        );
+    }
+
+
+    public function testRowReferencesAreRemembered(): void
+    {
+        $config = new \stdClass();
+        $config->constraints = new \stdClass();
+
+        $config->remember = new \stdClass();
+        $config->remember->id = 'fruit_ids';
+
+        $referenceStore = new ReferenceStore();
+
+        $sampler = new MatchedRows(
+            $config,
+            $referenceStore,
+            $this->source,
+            'fruits'
+        );
+
+        $sampler->getRows();
+
+        $this->assertSame([
+            '1', '2', '3', '4'
+        ], $referenceStore->getReferencesByName('fruit_ids'));
+    }
+
+    public function testRowsAreFilteredByReference(): void
+    {
+        $config = new \stdClass();
+        $config->constraints = new \stdClass();
+        $config->constraints->id = '$fruit_ids';
+
+        $referenceStore = new ReferenceStore();
+        $referenceStore->setReferencesByName('fruit_ids', [2, 3]);
+
+        $sampler = new MatchedRows(
+            $config,
+            $referenceStore,
+            $this->source,
+            'fruits'
+        );
+
+        $results = $sampler->getRows();
+
+        $this->assertEquals([
+            [
+                'id' => 2,
+                'name' => 'pear'
+            ],
+            [
+                'id' => 3,
+                'name' => 'apple'
+            ],
+        ], $results);
+    }
+
+    public function testAnExceptionIsThrownIfTableDoesNotExist(): void
+    {
+        $config = new \stdClass();
+        $config->constraints = new \stdClass();
+        $config->constraints->id = '$fruit_ids';
+
+        $sampler = new MatchedRows(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'TABLE_THAT_DOES_NOT_EXIST'
+        );
+
+        $this->expectException(TableNotFound::class);
+        $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
+        $sampler->getRows();
+    }
+}

--- a/tests/Sampler/NewestByIdTest.php
+++ b/tests/Sampler/NewestByIdTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace PHParrot\Parrot\Tests\Sampler;
+
+use PHParrot\Parrot\ReferenceStore;
+use PHParrot\Parrot\Sampler\Exception\RequiredConfigurationValueNotProvided;
+use PHParrot\Parrot\Sampler\Exception\TableNotFound;
+use PHParrot\Parrot\Sampler\NewestById;
+
+class NewestByIdTest extends SamplerTest
+{
+    public function testRowsAreFiltered(): void
+    {
+        $config = new \stdClass();
+        $config->quantity = 1;
+        $config->idField = 'id';
+
+        $sampler = new NewestById(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->assertEquals([[
+            'id' => 4,
+            'name' => 'cherry'
+        ]], $sampler->getRows());
+    }
+
+    public function testAnExceptionIsThrownIfTableDoesNotExist(): void
+    {
+        $config = new \stdClass();
+        $config->quantity = 1;
+        $config->idField = 'id';
+
+        $sampler = new NewestById(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'TABLE_THAT_DOES_NOT_EXIST'
+        );
+
+        $this->expectException(TableNotFound::class);
+        $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
+        $sampler->getRows();
+    }
+
+    public function testAnExceptionIsThrownIfQuantityParameterIsNotProvided(): void
+    {
+        $config = new \stdClass();
+        $config->idField = 'id';
+
+        $sampler = new NewestById(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->expectException(RequiredConfigurationValueNotProvided::class);
+        $this->expectExceptionMessage('The required parameter \'quantity\' was not provided');
+        $sampler->getRows();
+    }
+
+    public function testAnExceptionIsThrownIfIdFieldParameterIsNotProvided(): void
+    {
+        $config = new \stdClass();
+        $config->quantity = 1;
+
+        $sampler = new NewestById(
+            $config,
+            new ReferenceStore(),
+            $this->source,
+            'fruits'
+        );
+
+        $this->expectException(RequiredConfigurationValueNotProvided::class);
+        $this->expectExceptionMessage('The required parameter \'idField\' was not provided');
+        $sampler->getRows();
+    }
+}

--- a/tests/Sampler/NoneTest.php
+++ b/tests/Sampler/NoneTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PHParrot\Parrot\Tests\Sampler;
+
+use Doctrine\DBAL\DriverManager;
+use PHParrot\Parrot\Database\SourceDatabase;
+use PHParrot\Parrot\ReferenceStore;
+use PHParrot\Parrot\Sampler\None;
+use PHPUnit\Framework\TestCase;
+
+class NoneTest extends TestCase
+{
+    public function testNoRowsAreReturned(): void
+    {
+        $sampler = new None(
+            new \stdClass(),
+            new ReferenceStore(),
+            new SourceDatabase(
+                DriverManager::getConnection([
+                    'driver' => 'pdo_sqlite',
+                    'memory' => true
+                ])
+            ),
+            'TABLE_THAT_DOES_NOT_EXIST'
+        );
+
+        $this->assertSame([], $sampler->getRows());
+    }
+}

--- a/tests/Sampler/SamplerTest.php
+++ b/tests/Sampler/SamplerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PHParrot\Parrot\Tests\Sampler;
+
+use Doctrine\DBAL\DriverManager;
+use PHParrot\Parrot\Database\SourceDatabase;
+use PHPUnit\Framework\TestCase;
+
+abstract class SamplerTest extends TestCase
+{
+    /**
+     * @var SourceDatabase
+     */
+    protected $source;
+
+    protected function setUp(): void
+    {
+        $connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'memory' => true
+        ]);
+
+        $sql = explode(';', file_get_contents(__DIR__ . '/../fixtures/small-source.sql'));
+
+        foreach ($sql as $command) {
+            if (trim($command)) {
+                $connection->executeStatement($command);
+            }
+        }
+
+        $this->source = new SourceDatabase($connection);
+    }
+}

--- a/tests/SamplerTest.php
+++ b/tests/SamplerTest.php
@@ -4,6 +4,7 @@ namespace PHParrot\Parrot\Tests;
 
 use PHParrot\Parrot\ReferenceStore;
 use PHParrot\Parrot\Sampler\AllRows;
+use PHParrot\Parrot\Sampler\Exception\RequiredConfigurationValueNotProvided;
 use PHParrot\Parrot\Sampler\None;
 use PHParrot\Parrot\Sampler\MatchedRows;
 use PHParrot\Parrot\Sampler\Sampler;
@@ -43,7 +44,7 @@ class SamplerTest extends SqliteBasedTestCase
             'fruits'
         );
 
-        $sampler->execute();
+        $sampler->getRows();
 
         $this->assertCount(4, $referenceStore->getReferencesByName('fruit_ids'));
     }
@@ -65,7 +66,7 @@ class SamplerTest extends SqliteBasedTestCase
             'where' => ['basket_id > 1']
         ];
         $sampler = $this->generateMatched((object)$config);
-        $sampler->execute();
+        $sampler->getRows();
 
         $this->assertCount(2, $sampler->getRows());
     }
@@ -76,14 +77,14 @@ class SamplerTest extends SqliteBasedTestCase
             'where' => ['basket_id > 1']
         ];
         $sampler = $this->generateMatched((object)$config);
-        $sampler->execute();
+        $sampler->getRows();
         $this->assertCount(4, $sampler->getRows());
     }
 
     public function testMatchedNoConfigThrows(): void
     {
         $sampler = $this->generateMatched((object)[]);
-        self::expectException(\RuntimeException::class);
-        $sampler->execute();
+        self::expectException(RequiredConfigurationValueNotProvided::class);
+        $sampler->getRows();
     }
 }


### PR DESCRIPTION
Removing Doctrine query builder in favour of using raw SQL. The abstraction is an unnecessary mental overhead at the moment - we _may_ end up adding it back in later on