### PR TITLE
return a generator from the sampler

### DIFF
--- a/bin/dbsampler
+++ b/bin/dbsampler
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 
 <?php
+
 use Quidco\DbSampler\ConsoleRunner;
 
 $ownVendorAutoload = dirname(__DIR__) . '/vendor/autoload.php';

--- a/src/BaseSampler.php
+++ b/src/BaseSampler.php
@@ -48,7 +48,7 @@ abstract class BaseSampler implements Sampler
      */
     protected $config;
 
-    abstract protected function fetchData(): array;
+    abstract protected function fetchData(): iterable;
 
     public function __construct(
         \stdClass $config,
@@ -65,28 +65,17 @@ abstract class BaseSampler implements Sampler
         $this->tableName = $tableName;
     }
 
-    public function getRows(): array
+    public function getRows(): \Generator
     {
         $rows = $this->fetchData();
-        $references = [];
-
-        foreach ($this->referenceFields as $key => $variable) {
-            if (!array_key_exists($variable, $references)) {
-                $references[$variable] = [];
-            }
-        }
 
         foreach ($rows as $row) {
             // Store any reference fields we've been told to remember
             foreach ($this->referenceFields as $key => $variable) {
-                $references[$variable][] = $row[$key];
+                $this->referenceStore->setReferenceByName($variable, $row[$key]);
             }
-        }
 
-        foreach ($references as $reference => $values) {
-            $this->referenceStore->setReferencesByName($reference, $values);
+            yield $row;
         }
-
-        return $rows;
     }
 }

--- a/src/BaseSampler.php
+++ b/src/BaseSampler.php
@@ -48,7 +48,7 @@ abstract class BaseSampler implements Sampler
      */
     protected $config;
 
-    abstract protected function fetchData(): iterable;
+    abstract protected function fetchData(): \Generator;
 
     public function __construct(
         \stdClass $config,

--- a/src/Migrator/Migrator.php
+++ b/src/Migrator/Migrator.php
@@ -83,7 +83,7 @@ class Migrator
                 }
                 $writer->postWrite();
 
-                $this->logger->info("$setName: migrated '$table' with '" . $sampler->getName() . "': " . \count($rows) . " rows");
+                $this->logger->info("$setName: migrated '$table' with '" . $sampler->getName());
             } catch (\Exception $e) {
                 $this->logger->error(
                     "$setName: failed to migrate '$table' with '" . $sampler->getName() . "': " . $e->getMessage()

--- a/src/ReferenceStore.php
+++ b/src/ReferenceStore.php
@@ -11,6 +11,15 @@ class ReferenceStore
         $this->references[$name] = $references;
     }
 
+    public function setReferenceByName(string $name, string $reference): void
+    {
+        if (false === isset($this->references[$name])) {
+            $this->references[$name] = [];
+        }
+
+        $this->references[$name][] = $reference;
+    }
+
     public function getReferencesByName(string $name): array
     {
         return isset($this->references[$name]) ? $this->references[$name] : [];

--- a/src/Sampler/AllRows.php
+++ b/src/Sampler/AllRows.php
@@ -13,16 +13,18 @@ class AllRows extends BaseSampler
         return 'All';
     }
 
-    public function fetchData(): array
+    public function fetchData(): \Generator
     {
-        $query = "SELECT * FROM " . $this->source->getConnection()->quote($this->tableName);
+        $query = "SELECT * FROM " . $this->source->getConnection()->quoteIdentifier($this->tableName);
 
         if ($this->limit) {
             $query .= " LIMIT " . $this->limit;
         }
 
         try {
-            $statement = $this->source->getConnection()->executeQuery($query);
+            foreach ($this->source->getConnection()->iterateAssociative($query) as $row) {
+                yield $row;
+            }
         } catch (TableNotFoundException $exception) {
             throw new TableNotFound(
                 sprintf(
@@ -33,7 +35,5 @@ class AllRows extends BaseSampler
                 $exception
             );
         }
-
-        return $statement->fetchAllAssociative();
     }
 }

--- a/src/Sampler/NewestById.php
+++ b/src/Sampler/NewestById.php
@@ -14,7 +14,7 @@ class NewestById extends BaseSampler
         return 'NewestById';
     }
 
-    public function fetchData(): array
+    public function fetchData(): \Generator
     {
         if (!isset($this->config->idField)) {
             throw new RequiredConfigurationValueNotProvided('The required parameter \'idField\' was not provided');
@@ -32,7 +32,10 @@ class NewestById extends BaseSampler
                 $this->config->quantity
             );
 
-            $statement = $this->source->getConnection()->executeQuery($query);
+            foreach ($this->source->getConnection()->iterateAssociative($query) as $row) {
+                yield $row;
+            }
+
         } catch (TableNotFoundException $exception) {
             throw new TableNotFound(
                 sprintf(
@@ -43,7 +46,5 @@ class NewestById extends BaseSampler
                 $exception
             );
         }
-
-        return $statement->fetchAllAssociative();
     }
 }

--- a/src/Sampler/None.php
+++ b/src/Sampler/None.php
@@ -14,8 +14,10 @@ class None extends BaseSampler
         return 'None';
     }
 
-    public function fetchData(): array
+    public function fetchData(): \Generator
     {
-        return [];
+        foreach([] as $value) {
+            yield $value;
+        }
     }
 }

--- a/src/Sampler/Sampler.php
+++ b/src/Sampler/Sampler.php
@@ -8,5 +8,5 @@ interface Sampler
 
     // make this protected, and probably move everything onto BaseSampler
     // make BaseSampler implement this interface instead
-    public function getRows(): array;
+    public function getRows(): iterable;
 }

--- a/src/Sampler/Sampler.php
+++ b/src/Sampler/Sampler.php
@@ -8,5 +8,5 @@ interface Sampler
 
     // make this protected, and probably move everything onto BaseSampler
     // make BaseSampler implement this interface instead
-    public function getRows(): iterable;
+    public function getRows(): \Generator;
 }

--- a/tests/ReferenceStoreTest.php
+++ b/tests/ReferenceStoreTest.php
@@ -12,7 +12,8 @@ class ReferenceStoreTest extends TestCase
         $store = new ReferenceStore();
         $primes = [1, 3, 5, 7];
         $store->setReferencesByName('primes', $primes);
-        $this->assertEquals($primes, $store->getReferencesByName('primes'));
+        $store->setReferenceByName('primes', 11);
+        $this->assertEquals(\array_merge($primes, [11]), $store->getReferencesByName('primes'));
         $this->assertEquals([], $store->getReferencesByName('nosuch'));
     }
 }

--- a/tests/Sampler/AllRowsTest.php
+++ b/tests/Sampler/AllRowsTest.php
@@ -17,7 +17,7 @@ class AllRowsTest extends SamplerTest
             'fruits'
         );
 
-        $this->assertSame(4, count($sampler->getRows()));
+        $this->assertSame(4, count(iterator_to_array($sampler->getRows())));
     }
 
     public function testRowsAreFiltered(): void
@@ -33,7 +33,7 @@ class AllRowsTest extends SamplerTest
             'fruits'
         );
 
-        $this->assertSame(2, count($sampler->getRows()));
+        $this->assertSame(2, count(iterator_to_array($sampler->getRows())));
     }
 
     public function testAnExceptionIsThrownIfTableDoesNotExist(): void
@@ -47,6 +47,6 @@ class AllRowsTest extends SamplerTest
 
         $this->expectException(TableNotFound::class);
         $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 }

--- a/tests/Sampler/MatchedRowsTest.php
+++ b/tests/Sampler/MatchedRowsTest.php
@@ -36,7 +36,7 @@ class MatchedRowsTest extends SamplerTest
                     'name' => 'apple'
                 ]
             ],
-            $sampler->getRows()
+            iterator_to_array($sampler->getRows())
         );
     }
 
@@ -68,7 +68,7 @@ class MatchedRowsTest extends SamplerTest
                     'name' => 'cherry'
                 ]
             ],
-            $sampler->getRows()
+            iterator_to_array($sampler->getRows())
         );
     }
 
@@ -90,7 +90,7 @@ class MatchedRowsTest extends SamplerTest
             'fruits'
         );
 
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
 
         $this->assertSame([
             '1', '2', '3', '4'
@@ -113,7 +113,7 @@ class MatchedRowsTest extends SamplerTest
             'fruits'
         );
 
-        $results = $sampler->getRows();
+        $results = iterator_to_array($sampler->getRows());
 
         $this->assertEquals([
             [
@@ -142,6 +142,6 @@ class MatchedRowsTest extends SamplerTest
 
         $this->expectException(TableNotFound::class);
         $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 }

--- a/tests/Sampler/NewestByIdTest.php
+++ b/tests/Sampler/NewestByIdTest.php
@@ -25,7 +25,7 @@ class NewestByIdTest extends SamplerTest
         $this->assertEquals([[
             'id' => 4,
             'name' => 'cherry'
-        ]], $sampler->getRows());
+        ]], iterator_to_array($sampler->getRows()));
     }
 
     public function testAnExceptionIsThrownIfTableDoesNotExist(): void
@@ -43,7 +43,7 @@ class NewestByIdTest extends SamplerTest
 
         $this->expectException(TableNotFound::class);
         $this->expectExceptionMessage('Table TABLE_THAT_DOES_NOT_EXIST does not exist');
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 
     public function testAnExceptionIsThrownIfQuantityParameterIsNotProvided(): void
@@ -60,7 +60,7 @@ class NewestByIdTest extends SamplerTest
 
         $this->expectException(RequiredConfigurationValueNotProvided::class);
         $this->expectExceptionMessage('The required parameter \'quantity\' was not provided');
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 
     public function testAnExceptionIsThrownIfIdFieldParameterIsNotProvided(): void
@@ -77,6 +77,6 @@ class NewestByIdTest extends SamplerTest
 
         $this->expectException(RequiredConfigurationValueNotProvided::class);
         $this->expectExceptionMessage('The required parameter \'idField\' was not provided');
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 }

--- a/tests/Sampler/NoneTest.php
+++ b/tests/Sampler/NoneTest.php
@@ -24,6 +24,6 @@ class NoneTest extends TestCase
             'TABLE_THAT_DOES_NOT_EXIST'
         );
 
-        $this->assertSame([], $sampler->getRows());
+        $this->assertSame([], iterator_to_array($sampler->getRows()));
     }
 }

--- a/tests/SamplerTest.php
+++ b/tests/SamplerTest.php
@@ -19,7 +19,7 @@ class SamplerTest extends SqliteBasedTestCase
             $this->source,
             'test_table_name'
         );
-        $this->assertSame([], $sampler->getRows());
+        $this->assertSame([], iterator_to_array($sampler->getRows()));
     }
 
     public function testCopyAllSampler(): void
@@ -30,7 +30,7 @@ class SamplerTest extends SqliteBasedTestCase
             $this->source,
             'fruits'
         );
-        $this->assertCount(4, $sampler->getRows());
+        $this->assertCount(4, iterator_to_array($sampler->getRows()));
     }
 
     public function testCopyAllWithReferenceStore(): void
@@ -44,7 +44,7 @@ class SamplerTest extends SqliteBasedTestCase
             'fruits'
         );
 
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
 
         $this->assertCount(4, $referenceStore->getReferencesByName('fruit_ids'));
     }
@@ -66,9 +66,8 @@ class SamplerTest extends SqliteBasedTestCase
             'where' => ['basket_id > 1']
         ];
         $sampler = $this->generateMatched((object)$config);
-        $sampler->getRows();
 
-        $this->assertCount(2, $sampler->getRows());
+        $this->assertCount(2, iterator_to_array($sampler->getRows()));
     }
 
     public function testMatchedWhereNoConstraints(): void
@@ -85,6 +84,6 @@ class SamplerTest extends SqliteBasedTestCase
     {
         $sampler = $this->generateMatched((object)[]);
         self::expectException(RequiredConfigurationValueNotProvided::class);
-        $sampler->getRows();
+        iterator_to_array($sampler->getRows());
     }
 }


### PR DESCRIPTION
for big data sets, returning an `array` from the sampler means we quickly run out of memory. it's not efficient to do everything all at once, so we can just return the data one row at a time instead